### PR TITLE
specify that filenames must be lowercase

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -27,7 +27,7 @@ You should only submit **ONE** `Rmd` file.
 
 After completing these modifications, your `.Rmd` should look like this [sample bookdown `.Rmd`.](sample_project.Rmd){target="_blank"}
 
-1. Create a concise, descriptive name for your project. For instance, name it `base_r_ggplot_graph` or something similar if your work is about contrasting/working with base R graphics and **ggplot2** graphics. Check the `.Rmd` filenames in [the project repo](https://github.com/jtr13/cc20){target="_blank"} to make sure your name isn't already taken. Your project name should be words only and joined with underscores, i.e. **Do not include whitespace in the name.** Create a copy of your `.Rmd` file with the new name. 
+1. Create a concise, descriptive name for your project. For instance, name it `base_r_ggplot_graph` or something similar if your work is about contrasting/working with base R graphics and **ggplot2** graphics. Check the `.Rmd` filenames in [the project repo](https://github.com/jtr13/cc20){target="_blank"} to make sure your name isn't already taken. Your project name should be words only and joined with underscores, **no white space**. In addition, all letters must be **lowercase**. Create a copy of your `.Rmd` file with the new name. 
 
 2. Completely delete the YAML header (the section at the top of the `.Rmd` that includes name, title, date, output, etc.) including the `---` line.
     


### PR DESCRIPTION
Since GitHub sorts lowercase and uppercase filenames separately, it is much more convenient to only use one case.

@sallytt22: I've assigned this PR to you. Once you review it please merge it into the project. They you'll need to update your local version (pull), render the book, and push the files back up to GitHub, since we don't have GitHub Actions working yet. If you need help, let me know.